### PR TITLE
Make `GenerateDataReader` attribute internal

### DIFF
--- a/src/Qread/Sources/GenerateDataReaderAttribute.cs
+++ b/src/Qread/Sources/GenerateDataReaderAttribute.cs
@@ -23,7 +23,7 @@ internal static class GenerateDataReaderAttribute
                 namespace {{Constants.Namespace}};
 
                 [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct, AllowMultiple = false)]
-                public sealed class {{Name}} : System.Attribute
+                internal sealed class {{Name}} : System.Attribute
                 {
                     public bool IsExact { get; set; }
                 }


### PR DESCRIPTION
This prevents import conflicts when `ProjectA` references `Qread` and `ProjectB` references `ProjectA`. In this case, `ProjectB` will give an import conflict warning because both `ProjectA` and `ProjectB` generate their own `GenerateDataReader` attribute, but `ProjectA`'s is visible to `ProjectB`.